### PR TITLE
Make release assets script work for this repo

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
     # Enable manual trigger of this action.
     inputs:
+      user:
+        description: Container registry user.
+        default: sourcegraph
+        required: true
+
       tag:
         description: Git tag to checkout.
         required: true
@@ -11,6 +16,7 @@ on:
 env:
   DOCKER_TTY: ""  # using `docker run -t` seems to not work in github actions, maybe related to https://github.com/actions/runner/issues/241
   REL_TAG: ${{ github.event.inputs.tag }}
+  DOCKER_USER: ${{ github.event.inputs.user }}
 
 jobs:
   build-and-upload:
@@ -23,8 +29,8 @@ jobs:
         uses: docker/login-action@v1.14.1
         with:
           registry: docker.io
-          username: weaveworksigniteci
-          password: ${{ secrets.DOCKERHUB_PASSWORD_WEAVEWORKSIGNITECI }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build binaries and push sandbox image
         run: make release
       - name: Prepare assets


### PR DESCRIPTION
As the previous PRs, this adjusts the github actions pipeline further to work for this fork.